### PR TITLE
Enable checkstop analysis for the swift configuration

### DIFF
--- a/swift.config
+++ b/swift.config
@@ -78,9 +78,8 @@ set BMC_BT_LPC_IPMI
 
 # Enable Checkstop Analysis for both
 #   Runtime and IPLtime scenarios
-# Temporarily unset for Bringup
-unset ENABLE_CHECKSTOP_ANALYSIS
-unset IPLTIME_CHECKSTOP_ANALYSIS
+set ENABLE_CHECKSTOP_ANALYSIS
+set IPLTIME_CHECKSTOP_ANALYSIS
 
 # set for trace debug to console
 unset CONSOLE_OUTPUT_TRACE


### PR DESCRIPTION
This is working so we should enable it, that way we will be able to
debug checkstops better when they occur.